### PR TITLE
Bump Go to 1.26.3; update .gitignore

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -8,7 +8,7 @@ jobs:
   go-test:
     name: go-test
     runs-on: ubuntu-latest
-    container: golang:1.26-alpine
+    container: golang:1.26.3-alpine
     env:
       CGO_ENABLED: 0
       GOOS: linux
@@ -31,7 +31,7 @@ jobs:
     name: code-coverage
     
     runs-on: ubuntu-latest
-    container: golang:1.26-alpine
+    container: golang:1.26.3-alpine
     env:
       CGO_ENABLED: 0
     steps:
@@ -45,7 +45,7 @@ jobs:
   e2e:
     name: e2e
     runs-on: ubuntu-latest
-    container: golang:1.26-alpine
+    container: golang:1.26.3-alpine
     env:
       CGO_ENABLED: 0
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ conformance-dcr_report.json
 .idea/
 newmodelbank.json
 .DS_Store
+newozone.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26-alpine AS gobuilder
+FROM golang:1.26.3-alpine AS gobuilder
 RUN apk update && apk add git make bash ca-certificates
 
 ENV TERM xterm-color

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/OpenBankingUK/conformance-dcr
 
 go 1.26
 
+toolchain go1.26.3
+
 require (
 	github.com/go-ozzo/ozzo-validation v3.6.0+incompatible
 	github.com/golang-jwt/jwt/v4 v4.5.2


### PR DESCRIPTION
Pin Go patch version 1.26.3 across the project: update CI container images in .github/workflows/go.yml and the Dockerfile base image, and add `toolchain go1.26.3` to go.mod. Also add `newozone.json` to .gitignore. These changes ensure a consistent Go toolchain and more reproducible builds between CI and local environments.